### PR TITLE
FIX Use BASE_PATH to ensure consistent logfile path

### DIFF
--- a/src/AuditFactory.php
+++ b/src/AuditFactory.php
@@ -61,6 +61,11 @@ class AuditFactory implements Factory
         $logLevel    = $c->get(__CLASS__, 'logLevel');
         $keepForDays = $c->get(__CLASS__, 'keepForDays');
 
+        // Ensure log file path is relative to vendor directory (if not absolute)
+        if (strpos($logFile, '/') !== 0) {
+            $logFile = BASE_PATH . '/vendor/' . $logFile;
+        }
+
         switch ($service) {
             case 'AuditLogger':
                 $this->truncateLog($logFile, $keepForDays);


### PR DESCRIPTION
The logfile was previously being written to a path relative to wherever the script was originally invoked, which for web requests would sufficiently resolve to `{webroot}/public`, but for CLI processes would be whatever directory the `sake` command was run from (which in my case was the home directory of the user invoking a cronjob.)

This change ensures that the `BASE_PATH` derived by Silverstripe is enforced and honours the documented location of 'relative to vendor folder'.